### PR TITLE
Add initial web prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+# SkyDive Planner Prototype
+
+This repository contains a simple prototype for the **SkyDive Planner** app. It implements a very basic version of the design documented in `docs/design guide.md`.
+
+## Running
+
+Open `src/index.html` in a web browser to see the prototype. It includes the welcome screen, a login form, and a placeholder dashboard.
+
+The prototype is static and uses plain HTML, CSS, and JavaScript.

--- a/src/index.html
+++ b/src/index.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>SkyDive Planner</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div id="welcome-screen" class="screen active">
+        <h1>SkyDive Planner</h1>
+        <p>Design your skydives. Share your experience.</p>
+        <button id="btn-signin">Sign In</button>
+        <button id="btn-signup">Sign Up</button>
+    </div>
+
+    <div id="login-screen" class="screen">
+        <h2>Login</h2>
+        <input type="email" placeholder="Email" />
+        <input type="password" placeholder="Password" />
+        <button id="btn-login">Sign In</button>
+        <p><a href="#" id="link-to-signup">Sign Up</a> | <a href="#" id="link-back-welcome">Back</a></p>
+    </div>
+
+    <div id="dashboard-screen" class="screen">
+        <h2>Dashboard</h2>
+        <button id="btn-create">Create New Jump</button>
+        <div id="jumps-list"></div>
+        <p><a href="#" id="link-logout">Logout</a></p>
+    </div>
+
+    <script src="script.js"></script>
+</body>
+</html>

--- a/src/script.js
+++ b/src/script.js
@@ -1,0 +1,10 @@
+function showScreen(id) {
+    document.querySelectorAll('.screen').forEach(s => s.classList.remove('active'));
+    document.getElementById(id).classList.add('active');
+}
+
+document.getElementById('btn-signin').addEventListener('click', () => showScreen('login-screen'));
+document.getElementById('btn-signup').addEventListener('click', () => showScreen('login-screen'));
+document.getElementById('link-back-welcome').addEventListener('click', () => showScreen('welcome-screen'));
+document.getElementById('btn-login').addEventListener('click', () => showScreen('dashboard-screen'));
+document.getElementById('link-logout').addEventListener('click', () => showScreen('welcome-screen'));

--- a/src/style.css
+++ b/src/style.css
@@ -1,0 +1,42 @@
+body {
+    font-family: Helvetica, Arial, sans-serif;
+    background-color: #F7F7F7;
+    color: #2A3D66;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 100vh;
+}
+
+.screen {
+    display: none;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    width: 100%;
+}
+
+.screen.active {
+    display: flex;
+}
+
+button {
+    background-color: #5CA9E2;
+    border: none;
+    padding: 10px 20px;
+    margin: 5px;
+    color: white;
+    border-radius: 5px;
+    cursor: pointer;
+}
+
+input {
+    display: block;
+    padding: 10px;
+    margin: 5px 0;
+    border: 1px solid #A0A8B3;
+    border-radius: 5px;
+}


### PR DESCRIPTION
## Summary
- start front-end prototype based on design guide
- add simple HTML structure for welcome, login, and dashboard screens
- apply colors from design document
- document usage in README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687011dec5ec8332bc53ce7d7dd38c47