### PR TITLE
Add demo mode to bypass login

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,6 @@ This repository contains a simple prototype for the **SkyDive Planner** app. It 
 
 ## Running
 
-Open `src/index.html` in a web browser to see the prototype. It includes the welcome screen, a login form, and a placeholder dashboard.
+Open `src/index.html` in a web browser to see the prototype. It includes the welcome screen, a login form, and a placeholder dashboard. If you want to skip the login step, use the **Start Demo** button on the welcome screen.
 
 The prototype is static and uses plain HTML, CSS, and JavaScript.

--- a/src/index.html
+++ b/src/index.html
@@ -12,6 +12,7 @@
         <p>Design your skydives. Share your experience.</p>
         <button id="btn-signin">Sign In</button>
         <button id="btn-signup">Sign Up</button>
+        <button id="btn-demo">Start Demo</button>
     </div>
 
     <div id="login-screen" class="screen">

--- a/src/script.js
+++ b/src/script.js
@@ -5,6 +5,7 @@ function showScreen(id) {
 
 document.getElementById('btn-signin').addEventListener('click', () => showScreen('login-screen'));
 document.getElementById('btn-signup').addEventListener('click', () => showScreen('login-screen'));
+document.getElementById('btn-demo').addEventListener('click', () => showScreen('dashboard-screen'));
 document.getElementById('link-back-welcome').addEventListener('click', () => showScreen('welcome-screen'));
 document.getElementById('btn-login').addEventListener('click', () => showScreen('dashboard-screen'));
 document.getElementById('link-logout').addEventListener('click', () => showScreen('welcome-screen'));


### PR DESCRIPTION
## Summary
- add `Start Demo` button to welcome screen for skipping login
- wire the new button to go directly to dashboard
- update README with demo instructions

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6870255e42e4833283280791064f1938